### PR TITLE
build a static library

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,36 @@
 
 ## Installation
 
-You can install the developement version of the library through nimble with the following command
+You can install the development version of the library through nimble with the following command
 ```
 nimble install bearssl
 ```
+
+### Using a static BearSSL library
+
+By default, the bundled BearSSL source files will all be compiled and linked into your Nim project using `{.compile: ... .}` pragmas.
+To build and use a BearSSL static library instead (so only the used objects are linked), install it like this:
+
+```sh
+nimble buildBundledLib
+nimble install
+```
+
+Then add `-d:BearSSLBundledStaticLib` to your project's top-level "nim.cfg" or "config.nims".
+
+#### MSVC
+
+There's also experimental support for the MSVC compiler suite, if you can't use MingGW-w64.
+From a Visual Studio Development Command Prompt (the "Native Tools" one matching your architecture), run:
+
+```cmd
+cd bearssl\csources
+nmake lib
+cd ..\..
+nimble install
+```
+
+Don't forget to add `-d:BearSSLBundledStaticLib` to your project's top-level "nim.cfg" or "config.nims".
 
 ## License
 
@@ -25,4 +51,5 @@ or
 
 * Apache License, Version 2.0, ([LICENSE-APACHEv2](LICENSE-APACHEv2) or http://www.apache.org/licenses/LICENSE-2.0)
 
-at your option. This file may not be copied, modified, or distributed except according to those terms.
+at your option. These files may not be copied, modified, or distributed except according to those terms.
+

--- a/bearssl.nimble
+++ b/bearssl.nimble
@@ -1,4 +1,5 @@
 # Package
+mode          = ScriptMode.Verbose
 version       = "0.1.5"
 author        = "Status Research & Development GmbH"
 description   = "BearSSL wrapper"
@@ -6,3 +7,35 @@ license       = "MIT or Apache License 2.0"
 
 # Dependencies
 requires "nim >= 1.2.0"
+
+import strutils
+
+proc compileStaticLibrary() =
+  when defined(macosx):
+    var numCPUs = gorge("sysctl -n hw.ncpu").strip()
+  else:
+    var numCPUs = gorge("nproc").strip()
+  if numCPUs == "":
+    numCPUs = "1"
+
+  # add custom defines to `cdefs` (stuff like "-DBR_SLOW_MUL=1", not the ones already defined in "bearssl/csources/src/inner.h")
+  var
+    cdefs: seq[string] = @[]
+    envCflags = "-O3 -pipe"
+  if existsEnv("CFLAGS"):
+    envCflags = getEnv("CFLAGS")
+  let cflags = "CFLAGS=\"" & envCflags & " " & cdefs.join(" ") & "\""
+
+  withDir "bearssl/csources":
+    when defined(windows):
+      when defined(vcc):
+        # unclear how "vcc" can be defined in a *.nimble file: https://github.com/nim-lang/nimble/issues/726
+        exec("nmake lib")
+      else:
+        exec("mingw32-make CC=gcc -j" & numCPUs & " " & cflags & " lib")
+    else:
+      exec("make -j" & numCPUs & " " & cflags & " lib")
+
+task buildBundledLib, "build bundled library":
+  compileStaticLibrary()
+


### PR DESCRIPTION
instead of passing individual object files to the linker which, coupled
with absolute paths, leads to this kind of command line limit violation
on Windows (the max is 32767 chars): https://gist.githubusercontent.com/stefantalpalaru/0a95cb87f0de0b7591e9d7d531cfd621/raw/1529cf10e851bc3bed6077f7a3c8efd4ff4a97e7/azure1.txt

In addition, we're now relying on "src/inner.h" for feature and platform
detection - as upstream intended.