### PR TITLE
temporarily removing `raises: []` from bearSslFunc

### DIFF
--- a/bearssl/decls.nim
+++ b/bearssl/decls.nim
@@ -371,7 +371,7 @@ when sizeof(int) == 8:
 {.compile: bearToolsPath & "certs.c".}
 {.compile: bearToolsPath & "files.c".}
 
-{.pragma: bearSslFunc, cdecl, gcsafe, noSideEffect, raises: [].}
+{.pragma: bearSslFunc, cdecl, gcsafe, noSideEffect.}
 
 type
   HashClass* {.importc: "br_hash_class", header: "bearssl_hash.h", bycopy.} = object


### PR DESCRIPTION
This seems to have triggered a bug in the nim compiler, `raises` doesn't seem to work across module boundaries and it's currently failing compilation on libp2p. If there is workaround for this, then we can probably leave it on, otherwise we should disable it for now because it's breaking libp2p.
