### PR TITLE
update minimum required nim version

### DIFF
--- a/bearssl.nimble
+++ b/bearssl.nimble
@@ -5,4 +5,4 @@ description   = "BearSSL wrapper"
 license       = "MIT or Apache License 2.0"
 
 # Dependencies
-requires "nim >= 0.19.6"
+requires "nim >= 1.2.0"


### PR DESCRIPTION
https://github.com/status-im/nim-bearssl/commit/7d2a18115bc0592526e6ac4adfda9f43d0e2ca66
here you use `c_sizet`, that was added in nim 1.2