### PR TITLE
Fix BR_UNALIGNED define for ARM architectures.

### DIFF
--- a/bearssl/decls.nim
+++ b/bearssl/decls.nim
@@ -42,9 +42,11 @@ else:
   {.passC: "-DBR_USE_UNIX_TIME=1".}
   {.passC: "-DBR_USE_URANDOM=1".}
 
-when system.cpuEndian == bigEndian:
+when defined(i386) or defined(amd64):
+  {.passC: "-DBR_LE_UNALIGNED=1".}
+elif defined(powerpc) or defined(powerpc64):
   {.passC: "-DBR_BE_UNALIGNED=1".}
-else:
+elif defined(powerpc64el):
   {.passC: "-DBR_LE_UNALIGNED=1".}
 
 when sizeof(int) == 8:

--- a/bearssl/decls.nim
+++ b/bearssl/decls.nim
@@ -42,7 +42,7 @@ else:
   {.passC: "-DBR_USE_UNIX_TIME=1".}
   {.passC: "-DBR_USE_URANDOM=1".}
 
-when defined(i386) or defined(amd64):
+when defined(i386) or defined(amd64) or defined(arm64):
   {.passC: "-DBR_LE_UNALIGNED=1".}
 elif defined(powerpc) or defined(powerpc64):
   {.passC: "-DBR_BE_UNALIGNED=1".}


### PR DESCRIPTION
Reproduce original `inner.h` auto-configuration for `BR_UNALIGNED`
```
 420 #if !defined BR_LE_UNALIGNED && !defined BR_BE_UNALIGNED
 421 
 422 #if __i386 || __i386__ || __x86_64__ || _M_IX86 || _M_X64
 423 #define BR_LE_UNALIGNED   1
 424 #elif BR_POWER8_BE
 425 #define BR_BE_UNALIGNED   1
 426 #elif BR_POWER8_LE
 427 #define BR_LE_UNALIGNED   1
 428 #elif (__powerpc__ || __powerpc64__ || _M_PPC || _ARCH_PPC || _ARCH_PPC64) \
 429         && __BIG_ENDIAN__
 430 #define BR_BE_UNALIGNED   1
 431 #endif
 432 
 433 #endif
```
Link to original code https://bearssl.org/gitweb/?p=BearSSL;a=blob;f=src/inner.h;h=07e1d0a478e801a91580658918130fb8b595e407;hb=dda1f8a0c46e15b4a235163470ff700b2f13dcc5