### PR TITLE
Use bearSSL mirror + update to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,5 +184,6 @@ jobs:
         run: |
           # Nimble should automatically fetch submodules
           # git submodule update --init --recursive
-          nimble install -y --depsOnly
+          # nimble install -y --depsOnly
+          nimble install -y
           env TEST_LANG="${{ matrix.target.TEST_LANG }}" nimble test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,8 +182,6 @@ jobs:
         shell: bash
         working-directory: nim-bearssl
         run: |
-          # Nimble should automatically fetch submodules
-          # git submodule update --init --recursive
-          # nimble install -y --depsOnly
-          nimble install -y
+          git submodule update --init --recursive
+          nimble install -y --depsOnly
           env TEST_LANG="${{ matrix.target.TEST_LANG }}" nimble test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,7 @@ jobs:
         shell: bash
         working-directory: nim-bearssl
         run: |
-          git submodule update --init --recursive
+          # Nimble should automatically fetch submodules
+          # git submodule update --init --recursive
           nimble install -y --depsOnly
           env TEST_LANG="${{ matrix.target.TEST_LANG }}" nimble test

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "bearssl/csources"]
 	path = bearssl/csources
-	url = https://www.bearssl.org/git/BearSSL
+	url = https://github.com/status-im/BearSSL/


### PR DESCRIPTION
This uses the new mirror https://github.com/status-im/BearSSL/
which should help avoid the git clone issue we get from time to time, from @dryajov or in CI: 

![image](https://user-images.githubusercontent.com/22738317/108978336-c5704b00-7689-11eb-82f3-9bbb6ebfb8d4.png)

It also updates BearSSL to the latest commit which fixes a carry bug in Nist-P256 (unused in our codebase).