### PR TITLE
introduce `bearssl/random`

### DIFF
--- a/bearssl/random.nim
+++ b/bearssl/random.nim
@@ -34,7 +34,9 @@ proc new*[A](T: type HmacDrbgContext, seed: openArray[A]): ref HmacDrbgContext =
 
   doAssert seed.len > 0, "Seed must not be empty"
   let rng = (ref T)()
-  hmacDrbgInit(addr rng[], addr sha256Vtable, unsafeAddr seed[0], seed.len * sizeof(seed[0]))
+  hmacDrbgInit(
+    addr rng[], addr sha256Vtable, unsafeAddr seed[0],
+    seed.len * sizeof(seed[0]))
   rng
 
 const randMax = uint64.high
@@ -50,7 +52,7 @@ proc rand*(rng: var HmacDrbgContext, max: uint64): uint64 =
     return x
 
   while true:
-    if x <= randMax - (randMax mod max): # against modulo bias
+    if x < randMax - (randMax mod (max + 1)): # against modulo bias
       return x mod (max + 1) # inclusive of max
 
     hmacDrbgGenerate(addr rng, addr x, csize_t(sizeof(x)))

--- a/bearssl/random.nim
+++ b/bearssl/random.nim
@@ -40,7 +40,9 @@ proc new*[A](T: type HmacDrbgContext, seed: openArray[A]): ref HmacDrbgContext =
 const randMax = uint64.high
 
 proc rand*(rng: var HmacDrbgContext, max: uint64): uint64 =
-  ## Return a random number in the range [0, max] (inclusive)
+  ## Return a random number in the range 0..max (inclusive)
+  if max == 0: return 0
+
   var x: uint64
   hmacDrbgGenerate(addr rng, addr x, csize_t(sizeof(x)))
 
@@ -54,7 +56,7 @@ proc rand*(rng: var HmacDrbgContext, max: uint64): uint64 =
     hmacDrbgGenerate(addr rng, addr x, csize_t(sizeof(x)))
 
 proc rand*(rng: var HmacDrbgContext, max: Natural): int =
-  ## Return a random number in the range [0, max] (inclusive)
+  ## Return a random number in the range 0..max (inclusive)
   int(rand(rng, uint64(max)))
 
 proc sample*[T](rng: var HmacDrbgContext, a: openArray[T]): T =

--- a/bearssl/random.nim
+++ b/bearssl/random.nim
@@ -1,0 +1,90 @@
+## Adapters for working with primitive Nim types similar to std/random.
+##
+## This module contains thin wrappers but does not cover advanced randomness
+## concepts like distributions.
+
+import
+  std/typetraits,
+  ./abi/[hash, rand]
+
+export rand
+
+proc new*(T: type HmacDrbgContext): ref HmacDrbgContext =
+  ## Create a new randomness context intended to be shared between randomness
+  ## consumers - typically, a single instance per thread should be created.
+  ##
+  ## The context is seeded with randomness from the OS / system.
+  let seeder = prngSeederSystem(nil)
+  if seeder == nil:
+    return nil
+
+  let rng = (ref T)()
+  hmacDrbgInit(addr rng[], addr sha256Vtable, nil, 0)
+  if seeder(addr rng.vtable) == 0:
+    return nil
+
+  rng
+
+proc new*[A](T: type HmacDrbgContext, seed: openArray[A]): ref HmacDrbgContext =
+  ## Create a new randomness context with the given seed - typically, a single
+  ## instance per thread should be created.
+  ##
+  ## The context is seeded with the given non-empty `seed`.
+  static: doAssert supportsCopyMem(A)
+
+  doAssert seed.len > 0, "Seed must not be empty"
+  let rng = (ref T)()
+  hmacDrbgInit(addr rng[], addr sha256Vtable, unsafeAddr seed[0], seed.len * sizeof(seed[0]))
+  rng
+
+const randMax = uint64.high
+
+proc rand*(rng: var HmacDrbgContext, max: uint64): uint64 =
+  ## Return a random number in the range [0, max] (inclusive)
+  var x: uint64
+  hmacDrbgGenerate(addr rng, addr x, csize_t(sizeof(x)))
+
+  if max == randMax:
+    return x
+
+  while true:
+    if x <= randMax - (randMax mod max): # against modulo bias
+      return x mod (max + 1) # inclusive of max
+
+    hmacDrbgGenerate(addr rng, addr x, csize_t(sizeof(x)))
+
+proc rand*(rng: var HmacDrbgContext, max: Natural): int =
+  ## Return a random number in the range [0, max] (inclusive)
+  int(rand(rng, uint64(max)))
+
+proc sample*[T](rng: var HmacDrbgContext, a: openArray[T]): T =
+  ## Return a random item from `a` - `a` must not be empty
+  doAssert a.len > 0, "Cannot sample from empty array"
+  a[rng.rand(a.high)]
+
+proc shuffle*[T](rng: var HmacDrbgContext, a: var openArray[T]) =
+  ## Shuffle contents of a using the Durstenfeld method of the Fisher-Yates
+  ## shuffle
+  ## https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm
+  if a.len <= 1: return
+
+  for i in countdown(a.high, 1):
+    let j = rng.rand(i)
+    if i != j:
+      swap(a[i], a[j])
+
+proc fill*[T](rng: var HmacDrbgContext, a: var openArray[T]) =
+  ## Fill each item of `a` with random data
+  static: doAssert supportsCopyMem(T)
+  if a.len > 0:
+    hmacDrbgGenerate(addr rng, addr a[0], csize_t(sizeof(a[0]) * a.len))
+
+proc fill*[T](rng: var HmacDrbgContext, v: var T) =
+  ## Fill v with random data
+  static: doAssert supportsCopyMem(T)
+  when sizeof(T) > 0:
+    hmacDrbgGenerate(addr rng, addr v, csize_t(sizeof(T)) )
+
+proc fill*(rng: var HmacDrbgContext, T: type): T {.noinit.} =
+  ## Return an instance of T filled with random data
+  fill(rng, result)

--- a/tests/test_random.nim
+++ b/tests/test_random.nim
@@ -1,0 +1,28 @@
+import
+  unittest2,
+  ../bearssl/random
+
+{.used.}
+
+suite "random":
+  test "simple random ops":
+    let rng = HmacDrbgContext.new()
+
+    check:
+      rng[].rand(1) <= 1
+
+    var v: array[1024, byte]
+    fill(rng[], v)
+
+    let v2 = fill(rng[], array[1024, byte])
+    check:
+      v != default(array[1024, byte]) # possible, but not likely
+      v2 != default(array[1024, byte]) # possible, but not likely
+
+  test "seed":
+    let
+      rng = HmacDrbgContext.new([byte 0])
+      rng2 = HmacDrbgContext.new([byte 0])
+
+    check:
+      rng[].fill(uint64) == rng2[].fill(uint64)

--- a/tests/test_random.nim
+++ b/tests/test_random.nim
@@ -19,6 +19,15 @@ suite "random":
       v != default(array[1024, byte]) # possible, but not likely
       v2 != default(array[1024, byte]) # possible, but not likely
 
+      rng[].rand(0) == 0
+
+    # Just ensure it doesn't crash..
+    discard rng[].rand(uint64.high)
+
+    for i in 0..<1000:
+      check:
+        rng[].rand(1) in [uint64 0, 1]
+
   test "seed":
     let
       rng = HmacDrbgContext.new([byte 0])


### PR DESCRIPTION
`random` reimplements some of std/random, but with bearssl instead (we
have a few buggy copies of this module spread over various projects)

* split modules into smaller modules - allows using RNG without
compiling SSL
* deprecate functions with `Br` prefix - there are duplicate exports
both with and without `Br` for the same function and we use both in
consumers like chronos and libp2p

The Split likely needs more cleanup work - this is a first cut to get
the idea in place.