### PR TITLE
Add a nearly-working SSL test

### DIFF
--- a/bearssl/abi/bearssl_ssl.nim
+++ b/bearssl/abi/bearssl_ssl.nim
@@ -1240,18 +1240,18 @@ type
   SslioContext* {.importc: "br_sslio_context", header: "bearssl_ssl.h", bycopy.} = object
     engine* {.importc: "engine".}: ptr SslEngineContext
     lowRead* {.importc: "low_read".}: proc (readContext: pointer; data: ptr byte;
-                                        len: uint): cint {.importcFunc.}
+                                        len: uint): cint {.cdecl.}
     readContext* {.importc: "read_context".}: pointer
     lowWrite* {.importc: "low_write".}: proc (writeContext: pointer; data: ptr byte;
-        len: uint): cint {.importcFunc.}
+        len: uint): cint {.cdecl.}
     writeContext* {.importc: "write_context".}: pointer
 
 
 
 proc sslioInit*(ctx: var SslioContext; engine: ptr SslEngineContext; lowRead: proc (
-    readContext: pointer; data: ptr byte; len: uint): cint {.importcFunc.};
+    readContext: pointer; data: ptr byte; len: uint): cint {.cdecl.};
                readContext: pointer; lowWrite: proc (writeContext: pointer;
-    data: ptr byte; len: uint): cint {.importcFunc.}; writeContext: pointer) {.importcFunc,
+    data: ptr byte; len: uint): cint {.cdecl.}; writeContext: pointer) {.importcFunc,
     importc: "br_sslio_init", header: "bearssl_ssl.h".}
 
 proc sslioRead*(cc: var SslioContext; dst: pointer; len: uint): cint {.importcFunc,

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+test_ssl

--- a/tests/test_ssl.nim
+++ b/tests/test_ssl.nim
@@ -1,0 +1,80 @@
+import
+  unittest2,
+  std/strutils,
+  std/strformat,
+  std/net,
+  std/nativesockets,
+  ../bearssl,
+  ../bearssl/certs/cacert
+
+suite "SSL":
+  test "client":
+    let
+      hostname = "httpbin.org"
+      port = 443.Port
+    var
+      sc: SslClientContext
+      xc: X509MinimalContext
+      io: SslioContext
+      iobuffer: array[SSL_BUFSIZE_BIDI, char]
+
+    var socket = net.dial(hostname, port, buffered = true)
+    defer: socket.close()
+
+    proc lowRead(readContext: pointer; data: ptr byte; len: uint): cint {.cdecl.} =
+      var sock = cast[Socket](readContext)
+      result = sock.recv(cast[pointer](data), len.int).cint
+      checkpoint &"lowRead {len} -> {result}"
+      if result == 0:
+        checkpoint "Error reading"
+        return -1
+    
+    proc lowWrite(writeContext: pointer; data: ptr byte; len: uint): cint {.cdecl.} =
+      var sock = cast[Socket](writeContext)
+      result = sock.send(cast[pointer](data), len.int).cint
+      checkpoint &"lowWrite {len} -> {result}"
+      if result == 0:
+        checkpoint "Error writing"
+        return -1
+
+    sslClientInitFull(sc, xc.addr, MozillaTrustAnchors[0].addr, MozillaTrustAnchorsCount)
+    sslEngineSetBuffer(sc.eng, iobuffer.addr, SSL_BUFSIZE_BIDI, 1)
+    assert sslClientReset(sc, hostname, 0) == 1
+    sslioInit(io, sc.eng.addr, lowRead, socket[].addr, lowWrite, socket[].addr)
+    
+    checkpoint "sslInit finished"
+
+    # Send request
+    block:
+      # for 
+      # let payload = "Foo"
+      let payload = [
+        "GET /status/200 HTTP/1.0",
+        &"Host: {hostname}",
+        "User-Agent: nimbearssl/0.1.5",
+        "Accept: */*",
+        "",
+        "",
+      ].join("\r\n")
+      var buf = payload.cstring
+      check: sslioWriteAll(io, buf.addr, buf.len.uint) == 0
+      check: sslioFlush(io) == 0
+
+    # Read response
+    block:
+      const READ_BUFFER_LEN = 512
+      var response: string
+      var buf: array[READ_BUFFER_LEN, char]
+      while true:
+        var n = sslioRead(io, buf[0].addr, READ_BUFFER_LEN)
+        if n <= 0:
+          break
+        for i in 0..<n:
+          response.add buf[i]
+      checkpoint response
+      check: "200 OK" in response
+    
+    socket.close()
+    
+    check: sslEngineCurrentState(sc.eng) == SSL_CLOSED
+    check: sslEngineLastError(sc.eng) == 0


### PR DESCRIPTION
I'd like to use BearSSL for some HTTPS requests. This PR adds a nearly-working test case. I can't figure out what's wrong with the code and was wondering:

1. Would you like to have a working SSL test in here (once it's fixed, of course)?
2. Do you know what's wrong?

I'll keep poking at it, but if you have any tips, I'd appreciate it.

Right now, it's failing with error code 31 BR_ERR_IO: https://bearssl.org/apidoc/bearssl__ssl_8h.html#a5e4e4985aec3272bbb241137b16e79af But I don't have any indication what the IO error is.

