### PR TITLE
Fixed hmacSize definition

### DIFF
--- a/bearssl/abi/bearssl_hmac.nim
+++ b/bearssl/abi/bearssl_hmac.nim
@@ -37,7 +37,7 @@ type
 proc hmacInit*(ctx: var HmacContext; kc: var HmacKeyContext; outLen: uint) {.importcFunc,
     importc: "br_hmac_init", header: "bearssl_hmac.h".}
 
-proc hmacSize*(ctx: var HmacContext): uint {.inline, importcFunc, importc: "br_hmac_size".} =
+proc hmacSize*(ctx: var HmacContext): uint {.inline.} =
   return ctx.outLen
 
 


### PR DESCRIPTION
Which may cause compilation errors like [this](https://github.com/yglukhov/nim-jwt/issues/20)