### PR TITLE
fix warnings

### DIFF
--- a/bearssl/abi/bearssl_ssl.nim
+++ b/bearssl/abi/bearssl_ssl.nim
@@ -766,7 +766,7 @@ proc sslEngineInjectEntropy*(cc: var SslEngineContext; data: pointer; len: uint)
     importcFunc, importc: "br_ssl_engine_inject_entropy", header: "bearssl_ssl.h".}
 
 proc sslEngineGetServerName*(cc: var SslEngineContext): cstring {.inline.} =
-  return addr cc.serverName
+  return cast[cstring](addr cc.serverName)
 
 
 proc sslEngineGetVersion*(cc: var SslEngineContext): cuint {.inline.} =

--- a/bearssl/rand.nim
+++ b/bearssl/rand.nim
@@ -76,7 +76,10 @@ template generate*[V](ctx: var HmacDrbgContext, v: var seq[V]) =
 func generateBytes*(ctx: var HmacDrbgContext, n: int): seq[byte] =
   # https://github.com/nim-lang/Nim/issues/19357
   if n > 0:
-    result = newSeqUninitialized[byte](n)
+    result = when (NimMajor, NimMinor) < (2, 2):
+               newSeqUninitialized[byte](n)
+             else:
+               newSeqUninit[byte](n)
     ctx.generate(result)
 
 func generate*(ctx: var HmacDrbgContext, T: type): T {.noinit.} =


### PR DESCRIPTION
- Warning: Use `newSeqUninit` instead; newSeqUninitialized is deprecated
- Warning: unsafe conversion to 'cstring' from 'ptr array[0..255, char]'