### PR TITLE
Fix/incorrect parameter type in sha256update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ nimcache/
 nimble.develop
 nimble.paths
 /build/
+.nimble
 
 gen

--- a/bearssl/abi/bearssl_hash.nim
+++ b/bearssl/abi/bearssl_hash.nim
@@ -191,7 +191,7 @@ type
 proc sha256Init*(ctx: var Sha256Context) {.importcFunc, importc: "br_sha256_init",
                                        header: "bearssl_hash.h".}
 
-template sha256Update*(ctx: var Sha256Context; data: pointer; len: int) =
+template sha256Update*(ctx: var Sha256Context; data: pointer; len: uint) =
   sha224Update(ctx, data, len)
 
 proc sha256Out*(ctx: var Sha256Context; `out`: pointer) {.importcFunc,

--- a/tests/test_hash.nim
+++ b/tests/test_hash.nim
@@ -5,22 +5,27 @@ import std/[strutils, sequtils],
 {.used.}
 
 suite "Hashing":
+  let
+    input = [
+      "",
+      "a",
+      "abc",
+      "message digest",
+      "abcdefghijklmnopqrstuvwxyz",
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+      "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
+    ]
   test "MD5":
     let
-      input = ["",
-              "a",
-              "abc",
-              "message digest",
-              "abcdefghijklmnopqrstuvwxyz",
-              "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
-              "12345678901234567890123456789012345678901234567890123456789012345678901234567890"]
-      output = ["d41d8cd98f00b204e9800998ecf8427e",
-                "0cc175b9c0f1b6a831c399e269772661",
-                "900150983cd24fb0d6963f7d28e17f72",
-                "f96b697d7cb7938d525a2f31aaf161d0",
-                "c3fcd3d76192e4007dfb496cca67e13b",
-                "d174ab98d277d9f5a5611c2c9f419d9f",
-                "57edf4a22be3c955ac49da2e2107b67a"]
+      output = [
+        "d41d8cd98f00b204e9800998ecf8427e",
+        "0cc175b9c0f1b6a831c399e269772661",
+        "900150983cd24fb0d6963f7d28e17f72",
+        "f96b697d7cb7938d525a2f31aaf161d0",
+        "c3fcd3d76192e4007dfb496cca67e13b",
+        "d174ab98d277d9f5a5611c2c9f419d9f",
+        "57edf4a22be3c955ac49da2e2107b67a"
+      ]
 
     for i in 0 ..< input.len:
       var
@@ -30,4 +35,25 @@ suite "Hashing":
       md5Init(ctx)
       md5Update(ctx, input[i].cstring, uint input[i].len)
       md5Out(ctx, addr res[0])
+      check res.foldl(a & b.toHex(), "").toLower() == output[i]
+  test "SHA256":
+    let
+      output = [
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb",
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+        "f7846f55cf23e14eebeab5b4e1550cad5b509e3348fbc4efa3a1413d393cb650",
+        "71c480df93d6ae2f1efad1447c66c9525e316218cf51fc8d9ed832f2daf18b73",
+        "db4bfcbd4da0cd85a60c3c37d3fbd8805c77f15fc6b1fdfe614ee0a7c8fdb4c0",
+        "f371bc4a311f2b009eef952dd83ca80e2b60026c8e935592d0f9c308453c813e"
+      ]
+
+    for i in 0 ..< input.len:
+      var
+        ctx = Sha256Context()
+        res: array[sha256SIZE, uint8]
+
+      sha256Init(ctx)
+      sha256Update(ctx, input[i].cstring, uint input[i].len)
+      sha256Out(ctx, addr res[0])
       check res.foldl(a & b.toHex(), "").toLower() == output[i]


### PR DESCRIPTION
`sha256Update` is basically an alias for `sha224Update`, which is defined as follows:

```nim
template sha256Update*(ctx: var Sha256Context; data: pointer; len: int) =
  sha224Update(ctx, data, len)
```

Notice that the type of the `len` parameter is `int`.

`sha224Update`, however, is defined as follows:

```nim
proc sha224Update*(ctx: var Sha224Context; data: pointer; len: uint) {.importcFunc,
    importc: "br_sha224_update", header: "bearssl_hash.h".}
```

Here, notice that the type of the `len` argument is `uint`.

Now, when trying to create a sha256 hash, e.g.:

```nim
import bearssl/hash
import stew/byteutils

let data = "0123456789abcdef".toBytes
let buff = newSeq[byte](sha256SIZE)

var sha256HashCtx = Sha256Context()
sha256Init(sha256HashCtx)
sha256Update(sha256HashCtx, addr data[0], data.len)
sha256Out(sha256HashCtx2, addr buff[0])

echo "Hash out: ", buff.toHex
```

This will fails with:

```bash
/Users/mczenko/code/nim-learning/chronos/bearsslissue.nim(10, 13) Error: type mismatch
Expression: sha224Update(sha256HashCtx, addr(data[0]), len(data))
  [1] sha256HashCtx: Sha224Context
  [2] addr(data[0]): ptr byte
  [3] len(data): int

Expected one of (first mismatch at [position]):
[3] proc sha224Update(ctx: var Sha224Context; data: pointer; len: uint)
```

and when using `uint` (the expected interface):

```
sha256Update(sha256HashCtx, addr data[0], data.len.uint)
```

we will get:

```nim
/Users/mczenko/code/nim-learning/chronos/bearsslissue.nim(10, 13) Error: type mismatch
Expression: sha256Update(sha256HashCtx, addr(data[0]), uint(len(data)))
  [1] sha256HashCtx: Sha224Context
  [2] addr(data[0]): ptr byte
  [3] uint(len(data)): uint

Expected one of (first mismatch at [position]):
[3] template sha256Update(ctx: var Sha256Context; data: pointer; len: int)
```

Thus currently the way to get an ssh256 hash will be to directly use `sha224Update `:

```nim
import bearssl/hash
import stew/byteutils

let data = "0123456789abcdef".toBytes
let buff = newSeq[byte](sha256SIZE)

var sha256HashCtx = Sha256Context()
sha256Init(sha256HashCtx)
sha224Update(sha256HashCtx, addr data[0], data.len.uint)
sha256Out(sha256HashCtx, addr buff[0])

echo "Hash out: ", buff.toHex
```

This PR changes the type of the `len` parameter in `sha256Update` template to `uint`.