### PR TITLE
Checkout submodules when updating cacert

### DIFF
--- a/.github/workflows/update-cacert.yaml
+++ b/.github/workflows/update-cacert.yaml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Update
         id: update


### PR DESCRIPTION
update.sh needs submodules to successfully build brssl for .pem -> .c.