### PR TITLE
Impersonate app with branch protection bypass for push

### DIFF
--- a/.github/workflows/update-cacert.yaml
+++ b/.github/workflows/update-cacert.yaml
@@ -19,9 +19,16 @@ jobs:
       contents: write
 
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           submodules: recursive
 
       - name: Update


### PR DESCRIPTION
As this repo uses branch protections, the push from the update-cacert job fails, as it cannot satisfy them. Namely, the protections require the tests to be run first, and also require a pull request. Neither of this is necessary, as the tests are run after a commit anyway, and also the pull request is not actionable, it just creates noise.

To add the app, follow https://github.com/apps/status-im-actions The job will automatically start working after it is installed.