### PR TITLE
Use PR instead of a direct push for update-cert automation

### DIFF
--- a/.github/workflows/update-cacert.yaml
+++ b/.github/workflows/update-cacert.yaml
@@ -83,7 +83,6 @@ jobs:
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
           ref: ${{ env.BRANCH }}
-          fetch-depth: 2
 
       - name: Verify and trigger CI
         env:
@@ -93,9 +92,7 @@ jobs:
           # to protect against malicious code in ./update.sh dependencies
           # (e.g., the inner `make`) replacing binaries to leak DEPLOY_KEY
           git fetch --depth=1 origin "${{ github.event.repository.default_branch }}"
-          if [ "$(git rev-parse HEAD~1)" != "$(git rev-parse FETCH_HEAD)" ]; then
-            echo "::warning::Unexpected extra commits on branch"
-          elif git diff --name-only HEAD~1 | grep -qv '^bearssl/certs/'; then
+          if git diff --name-only FETCH_HEAD HEAD | grep -qv '^bearssl/certs/'; then
             echo "::warning::Unexpected changes outside bearssl/certs"
           else
             # Force-push with the DEPLOY_KEY to trigger CI


### PR DESCRIPTION
Pushing from actions fails due to branch protection rules. Create PR instead, when cacerts need updating.