### PR TITLE
Fetch parent commit as well in update-cert automation

### DIFF
--- a/.github/workflows/update-cacert.yaml
+++ b/.github/workflows/update-cacert.yaml
@@ -83,6 +83,7 @@ jobs:
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
           ref: ${{ env.BRANCH }}
+          fetch-depth: 2
 
       - name: Verify and trigger CI
         env:


### PR DESCRIPTION
Without fetch-depth: 2, amending the branch gets rid of the merge info.