### PR TITLE
v0.2.7

### DIFF
--- a/bearssl.nimble
+++ b/bearssl.nimble
@@ -1,7 +1,7 @@
 mode = ScriptMode.Verbose
 
 packageName   = "bearssl"
-version       = "0.2.6"
+version       = "0.2.7"
 author        = "Status Research & Development GmbH"
 description   = "BearSSL wrapper"
 license       = "MIT or Apache License 2.0"


### PR DESCRIPTION
* Fix/incorrect parameter type in sha256update
* Add patched secp256r1 verify for nimbus EL P256verify precompile
* Don't use quoteShell when compiling on bare metal
* Replace incorrect uint instances with csize_t
* Bump cacerts to 2026-02-22