### PR TITLE
Switch to official bearssl repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,5 @@
 [submodule "bearssl/csources"]
 	path = bearssl/csources
-	url = https://github.com/status-im/BearSSL
+	url = https://www.bearssl.org/git/BearSSL
+	ignore = dirty
+	branch = master


### PR DESCRIPTION
We currently track our own (outdated) mirror, without extra changes. Switch to upstream repo to stay up to date