### PR TITLE
Fix GCC 14+ -Wincompatible-pointer-types errors on const parameters

### DIFF
--- a/bearssl/abi/bearssl_aead.nim
+++ b/bearssl/abi/bearssl_aead.nim
@@ -1,5 +1,5 @@
 import
-  "."/[bearssl_block, bearssl_hash, csources]
+  "."/[bearssl_block, bearssl_hash, consttypes, csources]
 
 {.pragma: importcFunc, cdecl, gcsafe, noSideEffect, raises: [].}
 {.used.}
@@ -14,20 +14,20 @@ const
 type
   AeadClass* {.importc: "br_aead_class", header: "bearssl_aead.h", bycopy.} = object
     tagSize* {.importc: "tag_size".}: uint
-    reset* {.importc: "reset".}: proc (cc: ptr ptr AeadClass; iv: pointer; len: csize_t) {.
+    reset* {.importc: "reset".}: proc (cc: ptr ptr AeadClass; iv: ConstPointer; len: csize_t) {.
         importcFunc.}
-    aadInject* {.importc: "aad_inject".}: proc (cc: ptr ptr AeadClass; data: pointer;
+    aadInject* {.importc: "aad_inject".}: proc (cc: ptr ptr AeadClass; data: ConstPointer;
         len: csize_t) {.importcFunc.}
     flip* {.importc: "flip".}: proc (cc: ptr ptr AeadClass) {.importcFunc.}
     run* {.importc: "run".}: proc (cc: ptr ptr AeadClass; encrypt: cint; data: pointer;
                                len: csize_t) {.importcFunc.}
     getTag* {.importc: "get_tag".}: proc (cc: ptr ptr AeadClass; tag: pointer) {.importcFunc.}
-    checkTag* {.importc: "check_tag".}: proc (cc: ptr ptr AeadClass; tag: pointer): uint32 {.
+    checkTag* {.importc: "check_tag".}: proc (cc: ptr ptr AeadClass; tag: ConstPointer): uint32 {.
         importcFunc.}
     getTagTrunc* {.importc: "get_tag_trunc".}: proc (cc: ptr ptr AeadClass;
         tag: pointer; len: csize_t) {.importcFunc.}
     checkTagTrunc* {.importc: "check_tag_trunc".}: proc (cc: ptr ptr AeadClass;
-        tag: pointer; len: csize_t): uint32 {.importcFunc.}
+        tag: ConstPointer; len: csize_t): uint32 {.importcFunc.}
 
 
 
@@ -50,10 +50,10 @@ type
 proc gcmInit*(ctx: var GcmContext; bctx: ptr ptr BlockCtrClass; gh: Ghash) {.importcFunc,
     importc: "br_gcm_init", header: "bearssl_aead.h".}
 
-proc gcmReset*(ctx: var GcmContext; iv: pointer; len: csize_t) {.importcFunc,
+proc gcmReset*(ctx: var GcmContext; iv: ConstPointer; len: csize_t) {.importcFunc,
     importc: "br_gcm_reset", header: "bearssl_aead.h".}
 
-proc gcmAadInject*(ctx: var GcmContext; data: pointer; len: csize_t) {.importcFunc,
+proc gcmAadInject*(ctx: var GcmContext; data: ConstPointer; len: csize_t) {.importcFunc,
     importc: "br_gcm_aad_inject", header: "bearssl_aead.h".}
 
 proc gcmFlip*(ctx: var GcmContext) {.importcFunc, importc: "br_gcm_flip",
@@ -65,13 +65,13 @@ proc gcmRun*(ctx: var GcmContext; encrypt: cint; data: pointer; len: csize_t) {.
 proc gcmGetTag*(ctx: var GcmContext; tag: pointer) {.importcFunc, importc: "br_gcm_get_tag",
     header: "bearssl_aead.h".}
 
-proc gcmCheckTag*(ctx: var GcmContext; tag: pointer): uint32 {.importcFunc,
+proc gcmCheckTag*(ctx: var GcmContext; tag: ConstPointer): uint32 {.importcFunc,
     importc: "br_gcm_check_tag", header: "bearssl_aead.h".}
 
 proc gcmGetTagTrunc*(ctx: var GcmContext; tag: pointer; len: csize_t) {.importcFunc,
     importc: "br_gcm_get_tag_trunc", header: "bearssl_aead.h".}
 
-proc gcmCheckTagTrunc*(ctx: var GcmContext; tag: pointer; len: csize_t): uint32 {.importcFunc,
+proc gcmCheckTagTrunc*(ctx: var GcmContext; tag: ConstPointer; len: csize_t): uint32 {.importcFunc,
     importc: "br_gcm_check_tag_trunc", header: "bearssl_aead.h".}
 
 var gcmVtable* {.importc: "br_gcm_vtable", header: "bearssl_aead.h".}: AeadClass
@@ -104,16 +104,16 @@ proc eaxInit*(ctx: var EaxContext; bctx: ptr ptr BlockCtrcbcClass) {.importcFunc
 proc eaxCapture*(ctx: var EaxContext; st: ptr EaxState) {.importcFunc,
     importc: "br_eax_capture", header: "bearssl_aead.h".}
 
-proc eaxReset*(ctx: var EaxContext; nonce: pointer; len: csize_t) {.importcFunc,
+proc eaxReset*(ctx: var EaxContext; nonce: ConstPointer; len: csize_t) {.importcFunc,
     importc: "br_eax_reset", header: "bearssl_aead.h".}
 
-proc eaxResetPreAad*(ctx: var EaxContext; st: ptr EaxState; nonce: pointer; len: csize_t) {.
+proc eaxResetPreAad*(ctx: var EaxContext; st: ptr EaxState; nonce: ConstPointer; len: csize_t) {.
     importcFunc, importc: "br_eax_reset_pre_aad", header: "bearssl_aead.h".}
 
-proc eaxResetPostAad*(ctx: var EaxContext; st: ptr EaxState; nonce: pointer; len: csize_t) {.
+proc eaxResetPostAad*(ctx: var EaxContext; st: ptr EaxState; nonce: ConstPointer; len: csize_t) {.
     importcFunc, importc: "br_eax_reset_post_aad", header: "bearssl_aead.h".}
 
-proc eaxAadInject*(ctx: var EaxContext; data: pointer; len: csize_t) {.importcFunc,
+proc eaxAadInject*(ctx: var EaxContext; data: ConstPointer; len: csize_t) {.importcFunc,
     importc: "br_eax_aad_inject", header: "bearssl_aead.h".}
 
 proc eaxFlip*(ctx: var EaxContext) {.importcFunc, importc: "br_eax_flip",
@@ -129,13 +129,13 @@ proc eaxRun*(ctx: var EaxContext; encrypt: cint; data: pointer; len: csize_t) {.
 proc eaxGetTag*(ctx: var EaxContext; tag: pointer) {.importcFunc, importc: "br_eax_get_tag",
     header: "bearssl_aead.h".}
 
-proc eaxCheckTag*(ctx: var EaxContext; tag: pointer): uint32 {.importcFunc,
+proc eaxCheckTag*(ctx: var EaxContext; tag: ConstPointer): uint32 {.importcFunc,
     importc: "br_eax_check_tag", header: "bearssl_aead.h".}
 
 proc eaxGetTagTrunc*(ctx: var EaxContext; tag: pointer; len: csize_t) {.importcFunc,
     importc: "br_eax_get_tag_trunc", header: "bearssl_aead.h".}
 
-proc eaxCheckTagTrunc*(ctx: var EaxContext; tag: pointer; len: csize_t): uint32 {.importcFunc,
+proc eaxCheckTagTrunc*(ctx: var EaxContext; tag: ConstPointer; len: csize_t): uint32 {.importcFunc,
     importc: "br_eax_check_tag_trunc", header: "bearssl_aead.h".}
 
 var eaxVtable* {.importc: "br_eax_vtable", header: "bearssl_aead.h".}: AeadClass
@@ -156,11 +156,11 @@ type
 proc ccmInit*(ctx: var CcmContext; bctx: ptr ptr BlockCtrcbcClass) {.importcFunc,
     importc: "br_ccm_init", header: "bearssl_aead.h".}
 
-proc ccmReset*(ctx: var CcmContext; nonce: pointer; noncelen: csize_t; aadlen: uint64;
+proc ccmReset*(ctx: var CcmContext; nonce: ConstPointer; noncelen: csize_t; aadlen: uint64;
               datalen: uint64; taglen: csize_t): cint {.importcFunc,
     importc: "br_ccm_reset", header: "bearssl_aead.h".}
 
-proc ccmAadInject*(ctx: var CcmContext; data: pointer; len: csize_t) {.importcFunc,
+proc ccmAadInject*(ctx: var CcmContext; data: ConstPointer; len: csize_t) {.importcFunc,
     importc: "br_ccm_aad_inject", header: "bearssl_aead.h".}
 
 proc ccmFlip*(ctx: var CcmContext) {.importcFunc, importc: "br_ccm_flip",
@@ -172,5 +172,5 @@ proc ccmRun*(ctx: var CcmContext; encrypt: cint; data: pointer; len: csize_t) {.
 proc ccmGetTag*(ctx: var CcmContext; tag: pointer): uint {.importcFunc,
     importc: "br_ccm_get_tag", header: "bearssl_aead.h".}
 
-proc ccmCheckTag*(ctx: var CcmContext; tag: pointer): uint32 {.importcFunc,
+proc ccmCheckTag*(ctx: var CcmContext; tag: ConstPointer): uint32 {.importcFunc,
     importc: "br_ccm_check_tag", header: "bearssl_aead.h".}

--- a/bearssl/abi/bearssl_block.nim
+++ b/bearssl/abi/bearssl_block.nim
@@ -1,5 +1,5 @@
 import
-  "."/[csources, intx]
+  "."/[consttypes, csources, intx]
 
 {.pragma: importcFunc, cdecl, gcsafe, noSideEffect, raises: [].}
 {.used.}
@@ -64,7 +64,7 @@ type
     contextSize* {.importc: "context_size".}: uint
     blockSize* {.importc: "block_size".}: cuint
     logBlockSize* {.importc: "log_block_size".}: cuint
-    init* {.importc: "init".}: proc (ctx: ptr ptr BlockCbcencClass; key: pointer;
+    init* {.importc: "init".}: proc (ctx: ptr ptr BlockCbcencClass; key: ConstPointer;
                                  keylen: csize_t) {.importcFunc.}
     run* {.importc: "run".}: proc (ctx: ptr ptr BlockCbcencClass; iv: pointer;
                                data: pointer; len: csize_t) {.importcFunc.}
@@ -77,7 +77,7 @@ type
     contextSize* {.importc: "context_size".}: uint
     blockSize* {.importc: "block_size".}: cuint
     logBlockSize* {.importc: "log_block_size".}: cuint
-    init* {.importc: "init".}: proc (ctx: ptr ptr BlockCbcdecClass; key: pointer;
+    init* {.importc: "init".}: proc (ctx: ptr ptr BlockCbcdecClass; key: ConstPointer;
                                  keylen: csize_t) {.importcFunc.}
     run* {.importc: "run".}: proc (ctx: ptr ptr BlockCbcdecClass; iv: pointer;
                                data: pointer; len: csize_t) {.importcFunc.}
@@ -89,9 +89,9 @@ type
     contextSize* {.importc: "context_size".}: uint
     blockSize* {.importc: "block_size".}: cuint
     logBlockSize* {.importc: "log_block_size".}: cuint
-    init* {.importc: "init".}: proc (ctx: ptr ptr BlockCtrClass; key: pointer;
+    init* {.importc: "init".}: proc (ctx: ptr ptr BlockCtrClass; key: ConstPointer;
                                  keylen: csize_t) {.importcFunc.}
-    run* {.importc: "run".}: proc (ctx: ptr ptr BlockCtrClass; iv: pointer; cc: uint32;
+    run* {.importc: "run".}: proc (ctx: ptr ptr BlockCtrClass; iv: ConstPointer; cc: uint32;
                                data: pointer; len: csize_t): uint32 {.importcFunc.}
 
 
@@ -102,7 +102,7 @@ type
     contextSize* {.importc: "context_size".}: uint
     blockSize* {.importc: "block_size".}: cuint
     logBlockSize* {.importc: "log_block_size".}: cuint
-    init* {.importc: "init".}: proc (ctx: ptr ptr BlockCtrcbcClass; key: pointer;
+    init* {.importc: "init".}: proc (ctx: ptr ptr BlockCtrcbcClass; key: ConstPointer;
                                  keylen: csize_t) {.importcFunc.}
     encrypt* {.importc: "encrypt".}: proc (ctx: ptr ptr BlockCtrcbcClass; ctr: pointer;
                                        cbcmac: pointer; data: pointer; len: csize_t) {.
@@ -113,7 +113,7 @@ type
     ctr* {.importc: "ctr".}: proc (ctx: ptr ptr BlockCtrcbcClass; ctr: pointer;
                                data: pointer; len: csize_t) {.importcFunc.}
     mac* {.importc: "mac".}: proc (ctx: ptr ptr BlockCtrcbcClass; cbcmac: pointer;
-                               data: pointer; len: csize_t) {.importcFunc.}
+                               data: ConstPointer; len: csize_t) {.importcFunc.}
 
 
 

--- a/bearssl/abi/bearssl_ec.nim
+++ b/bearssl/abi/bearssl_ec.nim
@@ -1,5 +1,5 @@
 import
-  "."/[bearssl_hash, bearssl_rand, csources, intx]
+  "."/[bearssl_hash, bearssl_rand, consttypes, csources, intx]
 
 {.pragma: importcFunc, cdecl, gcsafe, noSideEffect, raises: [].}
 {.used.}
@@ -185,16 +185,16 @@ type
 type
   EcImpl* {.importc: "br_ec_impl", header: "bearssl_ec.h", bycopy.} = object
     supportedCurves* {.importc: "supported_curves".}: uint32
-    generator* {.importc: "generator".}: proc (curve: cint; len: var uint): ptr byte {.
+    generator* {.importc: "generator".}: proc (curve: cint; len: var uint): ConstPtrByte {.
         importcFunc.}
-    order* {.importc: "order".}: proc (curve: cint; len: var uint): ptr byte {.importcFunc.}
+    order* {.importc: "order".}: proc (curve: cint; len: var uint): ConstPtrByte {.importcFunc.}
     xoff* {.importc: "xoff".}: proc (curve: cint; len: var uint): uint {.importcFunc.}
-    mul* {.importc: "mul".}: proc (g: ptr byte; glen: csize_t; x: ptr byte;
+    mul* {.importc: "mul".}: proc (g: ptr byte; glen: csize_t; x: ConstPtrByte;
                                xlen: csize_t; curve: cint): uint32 {.importcFunc.}
-    mulgen* {.importc: "mulgen".}: proc (r: ptr byte; x: ptr byte; xlen: csize_t;
+    mulgen* {.importc: "mulgen".}: proc (r: ptr byte; x: ConstPtrByte; xlen: csize_t;
                                      curve: cint): uint {.importcFunc.}
-    muladd* {.importc: "muladd".}: proc (a: ptr byte; b: ptr byte; len: csize_t;
-                                     x: ptr byte; xlen: csize_t; y: ptr byte;
+    muladd* {.importc: "muladd".}: proc (a: ptr byte; b: ConstPtrByte; len: csize_t;
+                                     x: ConstPtrByte; xlen: csize_t; y: ConstPtrByte;
                                      ylen: csize_t; curve: cint): uint32 {.importcFunc.}
 
 

--- a/bearssl/abi/bearssl_hash.nim
+++ b/bearssl/abi/bearssl_hash.nim
@@ -1,5 +1,5 @@
 import
-  "."/[csources, inner]
+  "."/[consttypes, csources, inner]
 
 {.pragma: importcFunc, cdecl, gcsafe, noSideEffect, raises: [].}
 {.used.}
@@ -29,12 +29,12 @@ type
     contextSize* {.importc: "context_size".}: uint
     desc* {.importc: "desc".}: uint32
     init* {.importc: "init".}: proc (ctx: ConstPtrPtrHashClass) {.importcFunc.}
-    update* {.importc: "update".}: proc (ctx: ConstPtrPtrHashClass; data: pointer;
+    update* {.importc: "update".}: proc (ctx: ConstPtrPtrHashClass; data: ConstPointer;
                                      len: csize_t) {.importcFunc.}
     `out`* {.importc: "out".}: proc (ctx: ConstPtrPtrHashClass; dst: pointer) {.importcFunc.}
     state* {.importc: "state".}: proc (ctx: ConstPtrPtrHashClass; dst: pointer): uint64 {.
         importcFunc.}
-    setState* {.importc: "set_state".}: proc (ctx: ConstPtrPtrHashClass; stb: pointer;
+    setState* {.importc: "set_state".}: proc (ctx: ConstPtrPtrHashClass; stb: ConstPointer;
         count: uint64) {.importcFunc.}
 
 template hashdesc_Id*(id: untyped): untyped =
@@ -344,25 +344,25 @@ proc multihashOut*(ctx: var MultihashContext; id: cint; dst: pointer): uint {.im
     importc: "br_multihash_out", header: "bearssl_hash.h".}
 
 type
-  Ghash* {.importc: "br_ghash".} = proc (y: pointer; h: pointer; data: pointer; len: csize_t) {.importcFunc.}
+  Ghash* {.importc: "br_ghash".} = proc (y: pointer; h: ConstPointer; data: ConstPointer; len: csize_t) {.importcFunc.}
 
 
-proc ghashCtmul*(y: pointer; h: pointer; data: pointer; len: csize_t) {.importcFunc,
+proc ghashCtmul*(y: pointer; h: ConstPointer; data: ConstPointer; len: csize_t) {.importcFunc,
     importc: "br_ghash_ctmul", header: "bearssl_hash.h".}
 
-proc ghashCtmul32*(y: pointer; h: pointer; data: pointer; len: csize_t) {.importcFunc,
+proc ghashCtmul32*(y: pointer; h: ConstPointer; data: ConstPointer; len: csize_t) {.importcFunc,
     importc: "br_ghash_ctmul32", header: "bearssl_hash.h".}
 
-proc ghashCtmul64*(y: pointer; h: pointer; data: pointer; len: csize_t) {.importcFunc,
+proc ghashCtmul64*(y: pointer; h: ConstPointer; data: ConstPointer; len: csize_t) {.importcFunc,
     importc: "br_ghash_ctmul64", header: "bearssl_hash.h".}
 
-proc ghashPclmul*(y: pointer; h: pointer; data: pointer; len: csize_t) {.importcFunc,
+proc ghashPclmul*(y: pointer; h: ConstPointer; data: ConstPointer; len: csize_t) {.importcFunc,
     importc: "br_ghash_pclmul", header: "bearssl_hash.h".}
 
 proc ghashPclmulGet*(): Ghash {.importcFunc, importc: "br_ghash_pclmul_get",
                              header: "bearssl_hash.h".}
 
-proc ghashPwr8*(y: pointer; h: pointer; data: pointer; len: csize_t) {.importcFunc,
+proc ghashPwr8*(y: pointer; h: ConstPointer; data: ConstPointer; len: csize_t) {.importcFunc,
     importc: "br_ghash_pwr8", header: "bearssl_hash.h".}
 
 proc ghashPwr8Get*(): Ghash {.importcFunc, importc: "br_ghash_pwr8_get",

--- a/bearssl/abi/bearssl_pem.nim
+++ b/bearssl/abi/bearssl_pem.nim
@@ -1,5 +1,5 @@
 import
-  "."/[csources]
+  "."/[consttypes, csources]
 
 {.pragma: importcFunc, cdecl, gcsafe, noSideEffect, raises: [].}
 {.used.}
@@ -25,7 +25,7 @@ type
     err* {.importc: "err".}: cint
     hbuf* {.importc: "hbuf".}: ptr byte
     hlen* {.importc: "hlen".}: uint
-    dest* {.importc: "dest".}: proc (destCtx: pointer; src: pointer; len: csize_t) {.importcFunc.}
+    dest* {.importc: "dest".}: proc (destCtx: pointer; src: ConstPointer; len: csize_t) {.importcFunc.}
     destCtx* {.importc: "dest_ctx".}: pointer
     event* {.importc: "event".}: byte
     name* {.importc: "name".}: array[128, char]
@@ -41,16 +41,8 @@ proc pemDecoderPush*(ctx: var PemDecoderContext; data: pointer; len: csize_t): u
     importcFunc, importc: "br_pem_decoder_push", header: "bearssl_pem.h".}
 
 proc pemDecoderSetdest*(ctx: var PemDecoderContext; dest: proc (destCtx: pointer;
-    src: pointer; len: csize_t) {.importcFunc.}; destCtx: pointer) {.inline.} =
-  
-  # llvm-mingw will complaints about `incompatible function pointer types`
-  # because generated type missing const in the middle param
-  # `void (*)(void *, void *, size_t)`
-  when false:
-    ctx.dest = dest
-    
-  {.emit: """typedef void (*pem_decoder_dest_t)(void *, const void *, size_t);""" .}
-  {.emit: [ctx.dest, "= (pem_decoder_dest_t)", dest, ";"].}
+    src: ConstPointer; len: csize_t) {.importcFunc.}; destCtx: pointer) {.inline.} =
+  ctx.dest = dest
   ctx.destCtx = destCtx
 
 

--- a/bearssl/abi/bearssl_rand.nim
+++ b/bearssl/abi/bearssl_rand.nim
@@ -1,5 +1,5 @@
 import
-  "."/[bearssl_hash, bearssl_hmac, csources]
+  "."/[bearssl_hash, bearssl_hmac, consttypes, csources]
 
 {.pragma: importcFunc, cdecl, gcsafe, noSideEffect, raises: [].}
 {.used.}
@@ -14,11 +14,11 @@ const
 type
   PrngClass* {.importc: "br_prng_class", header: "bearssl_rand.h", bycopy.} = object
     contextSize* {.importc: "context_size".}: uint
-    init* {.importc: "init".}: proc (ctx: ptr ptr PrngClass; params: pointer;
-                                 seed: pointer; seedlen: csize_t) {.importcFunc.}
+    init* {.importc: "init".}: proc (ctx: ptr ptr PrngClass; params: ConstPointer;
+                                 seed: ConstPointer; seedlen: csize_t) {.importcFunc.}
     generate* {.importc: "generate".}: proc (ctx: ptr ptr PrngClass; `out`: pointer;
         len: csize_t) {.importcFunc.}
-    update* {.importc: "update".}: proc (ctx: ptr ptr PrngClass; seed: pointer;
+    update* {.importc: "update".}: proc (ctx: ptr ptr PrngClass; seed: ConstPointer;
                                      seedlen: csize_t) {.importcFunc.}
 
   PrngClassPointerConst* {.importc: "const br_prng_class**", header: "bearssl_rand.h", bycopy.} = pointer

--- a/bearssl/abi/bearssl_ssl.nim
+++ b/bearssl/abi/bearssl_ssl.nim
@@ -1,7 +1,7 @@
 import
   "."/[
     bearssl_aead, bearssl_block, bearssl_ec, bearssl_hash, bearssl_hmac,
-    bearssl_prf, bearssl_rand, bearssl_rsa, bearssl_x509, csources]
+    bearssl_prf, bearssl_rand, bearssl_rsa, bearssl_x509, consttypes, csources]
 
 {.pragma: importcFunc, cdecl, gcsafe, noSideEffect, raises: [].}
 {.used.}
@@ -489,6 +489,10 @@ type
 
   ProtocolNamesPointerConst* {.importc: "const char **", header: "bearssl_ssl.h",
                               bycopy.} = pointer
+  ConstPtrSslClientContext* {.importc: "const br_ssl_client_context *",
+                             header: "bearssl_ssl.h", bycopy.} = pointer
+  ConstPtrSslServerContext* {.importc: "const br_ssl_server_context *",
+                             header: "bearssl_ssl.h", bycopy.} = pointer
 
   SslEngineContext* {.importc: "br_ssl_engine_context", header: "bearssl_ssl.h",
                      bycopy.} = object
@@ -887,13 +891,13 @@ type
     startName* {.importc: "start_name".}: proc (
         pctx: ptr ptr SslClientCertificateClass; len: csize_t) {.importcFunc.}
     appendName* {.importc: "append_name".}: proc (
-        pctx: ptr ptr SslClientCertificateClass; data: ptr byte; len: csize_t) {.importcFunc.}
+        pctx: ptr ptr SslClientCertificateClass; data: ConstPtrByte; len: csize_t) {.importcFunc.}
     endName* {.importc: "end_name".}: proc (pctx: ptr ptr SslClientCertificateClass) {.
         importcFunc.}
     endNameList* {.importc: "end_name_list".}: proc (
         pctx: ptr ptr SslClientCertificateClass) {.importcFunc.}
     choose* {.importc: "choose".}: proc (pctx: ptr ptr SslClientCertificateClass;
-                                     cc: var SslClientContext; authTypes: uint32;
+                                     cc: ConstPtrSslClientContext; authTypes: uint32;
                                      choices: ptr SslClientCertificate) {.importcFunc.}
     doKeyx* {.importc: "do_keyx".}: proc (pctx: ptr ptr SslClientCertificateClass;
                                       data: ptr byte; len: var uint): uint32 {.
@@ -1037,7 +1041,7 @@ type
                          header: "bearssl_ssl.h", bycopy.} = object
     contextSize* {.importc: "context_size".}: uint
     choose* {.importc: "choose".}: proc (pctx: ptr ptr SslServerPolicyClass;
-                                     cc: var SslServerContext;
+                                     cc: ConstPtrSslServerContext;
                                      choices: ptr SslServerChoices): cint {.importcFunc.}
     doKeyx* {.importc: "do_keyx".}: proc (pctx: ptr ptr SslServerPolicyClass;
                                       data: ptr byte; len: var uint): uint32 {.

--- a/bearssl/abi/bearssl_x509.nim
+++ b/bearssl/abi/bearssl_x509.nim
@@ -1,5 +1,5 @@
 import
-  "."/[bearssl_ec, bearssl_hash, bearssl_rsa, csources]
+  "."/[bearssl_ec, bearssl_hash, bearssl_rsa, consttypes, csources]
 
 {.pragma: importcFunc, cdecl, gcsafe, noSideEffect, raises: [].}
 {.used.}
@@ -193,7 +193,7 @@ type
         serverName: cstring) {.importcFunc.}
     startCert* {.importc: "start_cert".}: proc (ctx: ptr ptr X509Class; length: uint32) {.
         importcFunc.}
-    append* {.importc: "append".}: proc (ctx: ptr ptr X509Class; buf: ptr byte;
+    append* {.importc: "append".}: proc (ctx: ptr ptr X509Class; buf: ConstPtrByte;
                                      len: csize_t) {.importcFunc.}
     endCert* {.importc: "end_cert".}: proc (ctx: ptr ptr X509Class) {.importcFunc.}
     endChain* {.importc: "end_chain".}: proc (ctx: ptr ptr X509Class): cuint {.importcFunc.}
@@ -368,7 +368,7 @@ type
     isCA* {.importc: "isCA".}: bool
     copyDn* {.importc: "copy_dn".}: byte
     appendDnCtx* {.importc: "append_dn_ctx".}: pointer
-    appendDn* {.importc: "append_dn".}: proc (ctx: pointer; buf: pointer; len: csize_t) {.
+    appendDn* {.importc: "append_dn".}: proc (ctx: pointer; buf: ConstPointer; len: csize_t) {.
         importcFunc.}
     hbuf* {.importc: "hbuf".}: ptr byte
     hlen* {.importc: "hlen".}: uint
@@ -379,7 +379,7 @@ type
 
 
 proc x509DecoderInit*(ctx: var X509DecoderContext; appendDn: proc (ctx: pointer;
-    buf: pointer; len: csize_t) {.importcFunc.}; appendDnCtx: pointer) {.importcFunc,
+    buf: ConstPointer; len: csize_t) {.importcFunc.}; appendDnCtx: pointer) {.importcFunc,
     importc: "br_x509_decoder_init", header: "bearssl_x509.h".}
 
 proc x509DecoderPush*(ctx: var X509DecoderContext; data: pointer; len: csize_t) {.importcFunc,

--- a/bearssl/abi/consttypes.nim
+++ b/bearssl/abi/consttypes.nim
@@ -1,0 +1,3 @@
+type
+  ConstPointer* {.importc: "const void *".} = pointer
+  ConstPtrByte* {.importc: "const unsigned char *".} = pointer

--- a/bearssl/aead.nim
+++ b/bearssl/aead.nim
@@ -1,4 +1,4 @@
 import
-  ./abi/bearssl_aead
+  ./abi/[bearssl_aead, consttypes]
 
-export bearssl_aead
+export bearssl_aead, consttypes

--- a/bearssl/blockx.nim
+++ b/bearssl/blockx.nim
@@ -1,4 +1,4 @@
 import
-  ./abi/bearssl_block
+  ./abi/[bearssl_block, consttypes]
 
-export bearssl_block
+export bearssl_block, consttypes

--- a/bearssl/ec.nim
+++ b/bearssl/ec.nim
@@ -1,4 +1,4 @@
 import
-  ./abi/bearssl_ec
+  ./abi/[bearssl_ec, consttypes]
 
-export bearssl_ec
+export bearssl_ec, consttypes

--- a/bearssl/hash.nim
+++ b/bearssl/hash.nim
@@ -1,4 +1,4 @@
 import
-  ./abi/bearssl_hash
+  ./abi/[bearssl_hash, consttypes]
 
-export bearssl_hash
+export bearssl_hash, consttypes

--- a/bearssl/pem.nim
+++ b/bearssl/pem.nim
@@ -1,8 +1,8 @@
 import
   typetraits,
-  ./abi/bearssl_pem
+  ./abi/[bearssl_pem, consttypes]
 
-export bearssl_pem
+export bearssl_pem, consttypes
 
 func init*(v: var PemDecoderContext) =
   # Careful, PemDecoderContext items are not copyable!
@@ -20,7 +20,7 @@ func push*(ctx: var PemDecoderContext, data: openArray[byte|char]): int =
 func setdest*(
     ctx: var PemDecoderContext;
     dest: proc (destCtx: pointer;
-      src: pointer; len: csize_t) {.cdecl, gcsafe, noSideEffect, raises: [].};
+      src: ConstPointer; len: csize_t) {.cdecl, gcsafe, noSideEffect, raises: [].};
     destCtx: pointer) =
   pemDecoderSetdest(ctx, dest, destCtx)
 

--- a/bearssl/rand.nim
+++ b/bearssl/rand.nim
@@ -1,8 +1,8 @@
 import
   typetraits,
-  ./abi/[bearssl_hash, bearssl_rand]
+  ./abi/[bearssl_hash, bearssl_rand, consttypes]
 
-export bearssl_rand
+export bearssl_rand, consttypes
 
 # About types used in helpers:
 # `bool` types are problematic because because they only use one bit of the

--- a/bearssl/ssl.nim
+++ b/bearssl/ssl.nim
@@ -1,4 +1,4 @@
 import
-  ./abi/bearssl_ssl
+  ./abi/[bearssl_ssl, consttypes]
 
-export bearssl_ssl
+export bearssl_ssl, consttypes

--- a/bearssl/x509.nim
+++ b/bearssl/x509.nim
@@ -1,4 +1,4 @@
 import
-  ./abi/bearssl_x509
+  ./abi/[bearssl_x509, consttypes]
 
-export bearssl_x509
+export bearssl_x509, consttypes

--- a/tests/test_pem.nim
+++ b/tests/test_pem.nim
@@ -14,7 +14,7 @@ suite "PEM":
 
     ctx.init()
 
-    proc test(dctx: pointer, data: pointer, len: csize_t) {.cdecl.} =
+    proc test(dctx: pointer, data: ConstPointer, len: csize_t) {.cdecl.} =
       cast[ptr bool](dctx)[] = true
 
     ctx.setdest(test, addr called)


### PR DESCRIPTION
- GCC 14+ elevated `-Wincompatible-pointer-types` to an error, causing compilation failures where BearSSL's C headers expect `const void *` / `const unsigned char *` but the Nim bindings generated `void *` / `unsigned char *`
- Introduce `ConstPointer` and `ConstPtrByte` types (`bearssl/abi/consttypes.nim`) mapped to const-qualified C types via `{.importc}`, and apply them across all ABI bindings
- Remove the `{.emit.}` cast workaround in `pemDecoderSetdest` — proper const types make it unnecessary
- Export `consttypes` from all wrapper modules so downstream code can use these types

User-defined callback signatures using `pointer` / `ptr byte` for const parameters must be updated to `ConstPointer` / `ConstPtrByte`. Both are aliases for `pointer` at the Nim level, but GCC 14+ rejects the mismatch in generated C function pointer types.

Close #83 

Related: #58, #61, #87