### PR TITLE
Restore plain `pointer` callback in pem setdest for source compatibility

### DIFF
--- a/bearssl/abi/bearssl_pem.nim
+++ b/bearssl/abi/bearssl_pem.nim
@@ -1,5 +1,5 @@
 import
-  "."/[consttypes, csources]
+  ./csources
 
 {.pragma: importcFunc, cdecl, gcsafe, noSideEffect, raises: [].}
 {.used.}
@@ -25,7 +25,7 @@ type
     err* {.importc: "err".}: cint
     hbuf* {.importc: "hbuf".}: ptr byte
     hlen* {.importc: "hlen".}: uint
-    dest* {.importc: "dest".}: proc (destCtx: pointer; src: ConstPointer; len: csize_t) {.importcFunc.}
+    dest* {.importc: "dest".}: proc (destCtx: pointer; src: pointer; len: csize_t) {.importcFunc.}
     destCtx* {.importc: "dest_ctx".}: pointer
     event* {.importc: "event".}: byte
     name* {.importc: "name".}: array[128, char]
@@ -41,8 +41,14 @@ proc pemDecoderPush*(ctx: var PemDecoderContext; data: pointer; len: csize_t): u
     importcFunc, importc: "br_pem_decoder_push", header: "bearssl_pem.h".}
 
 proc pemDecoderSetdest*(ctx: var PemDecoderContext; dest: proc (destCtx: pointer;
-    src: ConstPointer; len: csize_t) {.importcFunc.}; destCtx: pointer) {.inline.} =
-  ctx.dest = dest
+    src: pointer; len: csize_t) {.importcFunc.}; destCtx: pointer) {.inline.} =
+  # `src` deliberately stays `pointer` here instead of `ConstPointer` to keep
+  # source compatibility with existing callers such as nim-chronos v4.2.2, whose
+  # callback uses a plain `pointer`. The C field `dest` is const-qualified, so
+  # GCC 14+ rejects the implicit function-pointer conversion (`ctx.dest = dest`);
+  # bridge it with an explicit C cast instead.
+  {.emit: """typedef void (*pem_decoder_dest_t)(void *, const void *, size_t);""" .}
+  {.emit: [ctx.dest, "= (pem_decoder_dest_t)", dest, ";"].}
   ctx.destCtx = destCtx
 
 

--- a/bearssl/pem.nim
+++ b/bearssl/pem.nim
@@ -1,8 +1,8 @@
 import
   typetraits,
-  ./abi/[bearssl_pem, consttypes]
+  ./abi/bearssl_pem
 
-export bearssl_pem, consttypes
+export bearssl_pem
 
 func init*(v: var PemDecoderContext) =
   # Careful, PemDecoderContext items are not copyable!
@@ -20,7 +20,7 @@ func push*(ctx: var PemDecoderContext, data: openArray[byte|char]): int =
 func setdest*(
     ctx: var PemDecoderContext;
     dest: proc (destCtx: pointer;
-      src: ConstPointer; len: csize_t) {.cdecl, gcsafe, noSideEffect, raises: [].};
+      src: pointer; len: csize_t) {.cdecl, gcsafe, noSideEffect, raises: [].};
     destCtx: pointer) =
   pemDecoderSetdest(ctx, dest, destCtx)
 

--- a/tests/test_pem.nim
+++ b/tests/test_pem.nim
@@ -14,7 +14,7 @@ suite "PEM":
 
     ctx.init()
 
-    proc test(dctx: pointer, data: ConstPointer, len: csize_t) {.cdecl.} =
+    proc test(dctx: pointer, data: pointer, len: csize_t) {.cdecl.} =
       cast[ptr bool](dctx)[] = true
 
     ctx.setdest(test, addr called)


### PR DESCRIPTION
PR #89 changed `pemDecoderSetdest`/`setdest` to take `ConstPointer` for the destination callback's `src` parameter. Since `const void *` is rendered into the generated C function-pointer type, downstream callers that declare their callback with a plain `pointer` (e.g. nim-chronos's `itemAppend`) now fail to compile on GCC 14+ with
`-Wincompatible-pointer-types`.

Revert the pem `setdest` callback parameter and the `dest` field to `pointer`, and bridge to the const-qualified C field with an explicit `{.emit.}` cast as before #89. This restores the long-standing source contract so chronos builds without changes.

The other const fixes from #89 are left intact: they only annotate BearSSL-internal vtable fields, regular parameters, or real assignments to const C fields, none of which leak const into downstream-supplied callback signatures.