### PR TITLE
Restore plain `pointer` pem setdest callback via C shim

### DIFF
--- a/bearssl/abi/bearssl_pem.nim
+++ b/bearssl/abi/bearssl_pem.nim
@@ -9,7 +9,7 @@ const
 
 {.compile: bearCodecPath & "pemdec.c".}
 {.compile: bearCodecPath & "pemenc.c".}
-{.compile: currentSourcePath.parentDir / "pem_compat.c".}
+{.compile: currentSourcePath.parentDir & "/pem_compat.c".}
 
 type
   INNER_C_STRUCT_bearssl_pem_1* {.importc: "br_pem_decoder_context::no_name",

--- a/bearssl/abi/bearssl_pem.nim
+++ b/bearssl/abi/bearssl_pem.nim
@@ -1,5 +1,5 @@
 import
-  "."/[consttypes, csources]
+  ./csources
 
 {.pragma: importcFunc, cdecl, gcsafe, noSideEffect, raises: [].}
 {.used.}
@@ -9,6 +9,7 @@ const
 
 {.compile: bearCodecPath & "pemdec.c".}
 {.compile: bearCodecPath & "pemenc.c".}
+{.compile: currentSourcePath.parentDir / "pem_compat.c".}
 
 type
   INNER_C_STRUCT_bearssl_pem_1* {.importc: "br_pem_decoder_context::no_name",
@@ -25,7 +26,7 @@ type
     err* {.importc: "err".}: cint
     hbuf* {.importc: "hbuf".}: ptr byte
     hlen* {.importc: "hlen".}: uint
-    dest* {.importc: "dest".}: proc (destCtx: pointer; src: ConstPointer; len: csize_t) {.importcFunc.}
+    dest* {.importc: "dest".}: proc (destCtx: pointer; src: pointer; len: csize_t) {.importcFunc.}
     destCtx* {.importc: "dest_ctx".}: pointer
     event* {.importc: "event".}: byte
     name* {.importc: "name".}: array[128, char]
@@ -41,9 +42,13 @@ proc pemDecoderPush*(ctx: var PemDecoderContext; data: pointer; len: csize_t): u
     importcFunc, importc: "br_pem_decoder_push", header: "bearssl_pem.h".}
 
 proc pemDecoderSetdest*(ctx: var PemDecoderContext; dest: proc (destCtx: pointer;
-    src: ConstPointer; len: csize_t) {.importcFunc.}; destCtx: pointer) {.inline.} =
-  ctx.dest = dest
-  ctx.destCtx = destCtx
+    src: pointer; len: csize_t) {.importcFunc.}; destCtx: pointer) {.importcFunc,
+    importc: "nimbearssl_pem_decoder_setdest".}
+  ## `src` deliberately stays `pointer` here instead of `ConstPointer` to keep
+  ## source compatibility with existing callers such as nim-chronos v4.2.2, whose
+  ## callback uses a plain `pointer`. The C field `dest` is const-qualified, so
+  ## the const conversion is done with an explicit C cast inside the shim in
+  ## `pem_compat.c`, which GCC 14+ accepts.
 
 
 proc pemDecoderEvent*(ctx: var PemDecoderContext): cint {.importcFunc,

--- a/bearssl/abi/pem_compat.c
+++ b/bearssl/abi/pem_compat.c
@@ -1,0 +1,23 @@
+#include <stddef.h>
+#include "bearssl_pem.h"
+
+/*
+ * Source-compatibility shim for `br_pem_decoder_context.dest`.
+ *
+ * The field is `void (*)(void *, const void *, size_t)`, but nim-bearssl keeps
+ * the public `setdest` callback's `src` a plain `void *` so existing callers
+ * (e.g. nim-chronos, whose callback uses a plain pointer) keep compiling. The
+ * const conversion is performed here with an explicit C cast - which GCC 14+
+ * accepts - instead of in Nim `{.emit.}`. This mirrors bearssl's own
+ * `br_pem_decoder_setdest` inline setter, with the cast added.
+ *
+ * No companion header is needed: Nim generates the prototype for this function
+ * from the `importc` proc signature in `bearssl_pem.nim`.
+ */
+void
+nimbearssl_pem_decoder_setdest(br_pem_decoder_context *ctx,
+	void (*dest)(void *dest_ctx, void *src, size_t len), void *dest_ctx)
+{
+	ctx->dest = (void (*)(void *, const void *, size_t))dest;
+	ctx->dest_ctx = dest_ctx;
+}

--- a/bearssl/pem.nim
+++ b/bearssl/pem.nim
@@ -1,8 +1,8 @@
 import
   typetraits,
-  ./abi/[bearssl_pem, consttypes]
+  ./abi/bearssl_pem
 
-export bearssl_pem, consttypes
+export bearssl_pem
 
 func init*(v: var PemDecoderContext) =
   # Careful, PemDecoderContext items are not copyable!
@@ -20,7 +20,7 @@ func push*(ctx: var PemDecoderContext, data: openArray[byte|char]): int =
 func setdest*(
     ctx: var PemDecoderContext;
     dest: proc (destCtx: pointer;
-      src: ConstPointer; len: csize_t) {.cdecl, gcsafe, noSideEffect, raises: [].};
+      src: pointer; len: csize_t) {.cdecl, gcsafe, noSideEffect, raises: [].};
     destCtx: pointer) =
   pemDecoderSetdest(ctx, dest, destCtx)
 

--- a/tests/test_pem.nim
+++ b/tests/test_pem.nim
@@ -14,7 +14,7 @@ suite "PEM":
 
     ctx.init()
 
-    proc test(dctx: pointer, data: ConstPointer, len: csize_t) {.cdecl.} =
+    proc test(dctx: pointer, data: pointer, len: csize_t) {.cdecl.} =
       cast[ptr bool](dctx)[] = true
 
     ctx.setdest(test, addr called)


### PR DESCRIPTION
PR #89 changed `pemDecoderSetdest`/`setdest` to take `ConstPointer` for the callback's `src`. Because `const void *` is baked into the generated C function-pointer type, downstream callers that declare their callback with a plain `pointer` (e.g. nim-chronos v4.2.2's `itemAppend`) fail to compile on GCC 14+ with `-Wincompatible-pointer-types`.

Keep the `setdest` callback's `src` a plain `pointer` for source compatibility. Storing such a callback into the const-qualified `br_pem_decoder_context.dest` field needs an explicit function-pointer cast that GCC 14+ requires; perform it in a standalone `pem_compat.c` (mirroring BearSSL's own `br_pem_decoder_setdest` inline setter, with the cast added) and importc it as `pemDecoderSetdest`.

Related #94