### PR TITLE
Stop const-poisoning the shared callback typedef

### DIFF
--- a/bearssl/abi/bearssl_hash.nim
+++ b/bearssl/abi/bearssl_hash.nim
@@ -29,7 +29,7 @@ type
     contextSize* {.importc: "context_size".}: uint
     desc* {.importc: "desc".}: uint32
     init* {.importc: "init".}: proc (ctx: ConstPtrPtrHashClass) {.importcFunc.}
-    update* {.importc: "update".}: proc (ctx: ConstPtrPtrHashClass; data: ConstPointer;
+    update* {.importc: "update".}: proc (ctx: ConstPtrPtrHashClass; data: pointer;
                                      len: csize_t) {.importcFunc.}
     `out`* {.importc: "out".}: proc (ctx: ConstPtrPtrHashClass; dst: pointer) {.importcFunc.}
     state* {.importc: "state".}: proc (ctx: ConstPtrPtrHashClass; dst: pointer): uint64 {.

--- a/bearssl/abi/bearssl_x509.nim
+++ b/bearssl/abi/bearssl_x509.nim
@@ -17,6 +17,7 @@ const
 {.compile: bearX509Path & "x509_knownkey.c".}
 {.compile: bearX509Path & "x509_minimal.c".}
 {.compile: bearX509Path & "x509_minimal_full.c".}
+{.compile: currentSourcePath.parentDir & "/x509_compat.c".}
 
 const
   ERR_X509_OK* = 32
@@ -368,7 +369,7 @@ type
     isCA* {.importc: "isCA".}: bool
     copyDn* {.importc: "copy_dn".}: byte
     appendDnCtx* {.importc: "append_dn_ctx".}: pointer
-    appendDn* {.importc: "append_dn".}: proc (ctx: pointer; buf: ConstPointer; len: csize_t) {.
+    appendDn* {.importc: "append_dn".}: proc (ctx: pointer; buf: pointer; len: csize_t) {.
         importcFunc.}
     hbuf* {.importc: "hbuf".}: ptr byte
     hlen* {.importc: "hlen".}: uint
@@ -379,8 +380,16 @@ type
 
 
 proc x509DecoderInit*(ctx: var X509DecoderContext; appendDn: proc (ctx: pointer;
-    buf: ConstPointer; len: csize_t) {.importcFunc.}; appendDnCtx: pointer) {.importcFunc,
-    importc: "br_x509_decoder_init", header: "bearssl_x509.h".}
+    buf: pointer; len: csize_t) {.importcFunc.}; appendDnCtx: pointer) {.importcFunc,
+    importc: "nimbearssl_x509_decoder_init".}
+  ## `buf` stays `pointer`, not `ConstPointer`: the PEM `setdest`, hash `update`
+  ## and this `appendDn` callback are structurally identical, so Nim emits one
+  ## shared C `typedef` for all three. A `ConstPointer` alias renders that typedef
+  ## `const` in some translation units (compilation-order dependent), breaking
+  ## non-const downstream callbacks (e.g. nim-chronos's PEM `itemAppend`) under
+  ## `-Werror=incompatible[-function]-pointer-types`. const-correctness toward the
+  ## real C function is restored by the `x509_compat.c` shim. Mirrors
+  ## `pemDecoderSetdest`.
 
 proc x509DecoderPush*(ctx: var X509DecoderContext; data: pointer; len: csize_t) {.importcFunc,
     importc: "br_x509_decoder_push", header: "bearssl_x509.h".}

--- a/bearssl/abi/x509_compat.c
+++ b/bearssl/abi/x509_compat.c
@@ -1,0 +1,22 @@
+#include <stddef.h>
+#include "bearssl_x509.h"
+
+/*
+ * Source-compatibility shim for `br_x509_decoder_init`'s `append_dn` callback.
+ *
+ * nim-bearssl keeps the public callback's middle arg a plain `void *` (not
+ * `const void *`) so non-const downstream callbacks keep compiling and the C
+ * typedef shared with PEM `setdest`/hash `update` stays non-const; see
+ * `x509DecoderInit` in bearssl_x509.nim. The const conversion the real callback
+ * type needs is done with an explicit cast here (accepted by GCC 14+), mirroring
+ * `pem_compat.c`. Nim generates this function's prototype from its `importc`
+ * proc, so no companion header is needed.
+ */
+void
+nimbearssl_x509_decoder_init(br_x509_decoder_context *ctx,
+	void (*append_dn)(void *append_dn_ctx, void *buf, size_t len),
+	void *append_dn_ctx)
+{
+	br_x509_decoder_init(ctx,
+		(void (*)(void *, const void *, size_t))append_dn, append_dn_ctx);
+}


### PR DESCRIPTION
PR #89 switched the x509 `append_dn` and hash `update` callback params to `ConstPointer`. These are structurally identical to the PEM `setdest` callback, so Nim collapses all three into one generated C typedef and renders it `const` in some translation units (compilation-order dependent). Non-const downstream callbacks -- e.g. chronos v4.2.2's PEM `itemAppend` -- then fail under GCC 14+ / clang `-Werror=incompatible-pointer-types`. same typedef, so the poison persisted.

Revert the `append_dn` / `update` fields to plain `pointer` and route `x509DecoderInit` through a C shim (`x509_compat.c`) that casts to the const-qualified `br_x509_decoder_init` signature, mirroring `pem_compat.c`. The shared typedef is now uniformly non-const, while const-correctness toward the real C function is preserved.