### PR TITLE
Stop the X509 class `append` callback from poisoning the shared typedef

### DIFF
--- a/bearssl/abi/bearssl_x509.nim
+++ b/bearssl/abi/bearssl_x509.nim
@@ -194,8 +194,14 @@ type
         serverName: ConstCstring) {.importcFunc.}
     startCert* {.importc: "start_cert".}: proc (ctx: X509ClassPointerConst; length: uint32) {.
         importcFunc.}
-    append* {.importc: "append".}: proc (ctx: X509ClassPointerConst; buf: ConstPtrByte;
+    append* {.importc: "append".}: proc (ctx: pointer; buf: pointer;
                                      len: csize_t) {.importcFunc.}
+      ## Plain `pointer`, not the `const` aliases: a `const` spelling here poisons
+      ## the C `typedef` shared with the decoder/PEM/hash callbacks (order-dependent),
+      ## breaking them under clang `-Werror`. The real C field stays `const`-qualified.
+      ## Trade-off: `addr cls.append` (incl. `unittest2`'s `check cls.append != nil`)
+      ## then mismatches the `const` header field under clang
+      ## `-Wincompatible-pointer-types`; use the field by value, not by address.
     endCert* {.importc: "end_cert".}: proc (ctx: X509ClassPointerConst) {.importcFunc.}
     endChain* {.importc: "end_chain".}: proc (ctx: X509ClassPointerConst): cuint {.importcFunc.}
     getPkey* {.importc: "get_pkey".}: proc (ctx: X509ClassPointerConstConst;


### PR DESCRIPTION
Follow-up to #95 / #97, which switched the PEM `setdest` / decoder `appendDn` / hash `update` callbacks to plain `pointer` but left `br_x509_class.append` on the `const` aliases. Being `= pointer`, they're structurally identical, so Nim folds all four into one C typedef -- and the `const` spelling can turn that shared typedef `const` in some translation units (order-dependent), breaking the plain-pointer sites (e.g. `x509_compat.c`) under clang 16+'s default-error `-Wincompatible-function-pointer-types` (or gcc `-Werror`).

Spell its params plain `pointer` to pin the typedef to `void*`; the real C field stays `const`-qualified via the header, so const-typed downstream callbacks still match. See the field's doc comment for the `addr cls.append` trade-off.

Works around nim-lang/Nim#25931.